### PR TITLE
Hide buttons in AdonisWindow according to ResizeMode

### DIFF
--- a/AdonisUI.ClassicTheme/NamedStyles/WindowButton.xaml
+++ b/AdonisUI.ClassicTheme/NamedStyles/WindowButton.xaml
@@ -28,7 +28,8 @@
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Opacity="0"/>
 
-                        <ContentPresenter Content="{TemplateBinding Content}"
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Content="{TemplateBinding Content}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -59,6 +60,9 @@
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="TextElement.Foreground" TargetName="ContentPresenter" Value="{DynamicResource {x:Static adonisUi:Brushes.DisabledForegroundBrush}}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/AdonisUI/Controls/AdonisWindow.xaml
+++ b/AdonisUI/Controls/AdonisWindow.xaml
@@ -174,6 +174,17 @@
                             <Setter Property="Foreground" TargetName="PART_CloseButton" Value="#ffffff"/>
                         </Trigger>
 
+                        <Trigger Property="ResizeMode" Value="NoResize">
+                            <Setter TargetName="PART_MinimizeButton" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_MaximizeRestoreButton" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+
+                        <Trigger Property="ResizeMode" Value="CanMinimize">
+                            <Setter TargetName="PART_MaximizeRestoreButton" Property="IsEnabled" Value="False"/>
+                            <Setter Property="Foreground" TargetName="PART_MaximizeRestoreButton"
+                                    Value="{DynamicResource {x:Static adonisUi:Brushes.DisabledForegroundBrush}}"/>
+                        </Trigger>
+
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/AdonisUI/Controls/AdonisWindow.xaml
+++ b/AdonisUI/Controls/AdonisWindow.xaml
@@ -97,9 +97,13 @@
                                                     Style="{DynamicResource {x:Static adonisUi:Styles.WindowButton}}"
                                                     Foreground="{TemplateBinding TitleBarForeground}"
                                                     Background="{TemplateBinding WindowButtonHighlightBrush}">
-                                                <ContentControl ContentTemplate="{DynamicResource {x:Static adonisUi:Icons.WindowMinimize}}"
+                                                <Button.ContentTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl ContentTemplate="{DynamicResource {x:Static adonisUi:Icons.WindowMinimize}}"
                                                                 Width="10"
                                                                 Height="10"/>
+                                                    </DataTemplate>
+                                                </Button.ContentTemplate>
                                             </Button>
 
                                             <Button x:Name="PART_MaximizeRestoreButton"
@@ -107,18 +111,26 @@
                                                     Style="{DynamicResource {x:Static adonisUi:Styles.WindowButton}}"
                                                     Foreground="{TemplateBinding TitleBarForeground}"
                                                     Background="{TemplateBinding WindowButtonHighlightBrush}">
-                                                <ContentControl ContentTemplate="{DynamicResource {x:Static adonisUi:Icons.WindowMaximize}}"
+                                                <Button.ContentTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl ContentTemplate="{DynamicResource {x:Static adonisUi:Icons.WindowMaximize}}"
                                                                 Width="10"
                                                                 Height="10"/>
+                                                    </DataTemplate>
+                                                </Button.ContentTemplate>
                                             </Button>
 
                                             <Button x:Name="PART_CloseButton"
                                                     Grid.Column="2"
                                                     Style="{DynamicResource {x:Static adonisUi:Styles.WindowCloseButton}}"
                                                     Foreground="{TemplateBinding TitleBarForeground}">
-                                                <ContentControl ContentTemplate="{DynamicResource {x:Static adonisUi:Icons.WindowClose}}"
+                                                <Button.ContentTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl ContentTemplate="{DynamicResource {x:Static adonisUi:Icons.WindowClose}}"
                                                                 Width="10"
                                                                 Height="10"/>
+                                                    </DataTemplate>
+                                                </Button.ContentTemplate>
                                             </Button>
                                         </Grid>
                                     </Grid>
@@ -181,8 +193,6 @@
 
                         <Trigger Property="ResizeMode" Value="CanMinimize">
                             <Setter TargetName="PART_MaximizeRestoreButton" Property="IsEnabled" Value="False"/>
-                            <Setter Property="Foreground" TargetName="PART_MaximizeRestoreButton"
-                                    Value="{DynamicResource {x:Static adonisUi:Brushes.DisabledForegroundBrush}}"/>
                         </Trigger>
 
                     </ControlTemplate.Triggers>


### PR DESCRIPTION
The default WPF window hides the minimize and maximize buttons if `ResizeMode` is set to `NoResize`. Also, the maximize button is disabled if it's set to `CanMinimize` [[link](https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.resizemode?view=netframework-4.8#remarks)].
This PR adds this behaviour for `AdonisWindow`.

PS: Thanks for your great work on this library!
