### PR TITLE
Fix exception thrown when changing themes when application uses relative and absolute URIs

### DIFF
--- a/AdonisUI/ResourceLocator.cs
+++ b/AdonisUI/ResourceLocator.cs
@@ -40,7 +40,7 @@ namespace AdonisUI
 
         private static ResourceDictionary FindColorSchemeInResources(ResourceDictionary resourceDictionary, Uri[] knownColorSchemes)
         {
-            if (knownColorSchemes.Any(scheme => resourceDictionary.Source != null && resourceDictionary.Source.AbsoluteUri.Equals(scheme.AbsoluteUri)))
+            if (knownColorSchemes.Any(scheme => resourceDictionary.Source != null && resourceDictionary.Source.IsAbsoluteUri && resourceDictionary.Source.AbsoluteUri.Equals(scheme.AbsoluteUri)))
                 return resourceDictionary;
 
             if (!resourceDictionary.MergedDictionaries.Any())


### PR DESCRIPTION
I am using a slightly modified version of this library in my source code (as a source project), however I have not modified any of the loading code.

In my app's App.xaml I add a merged dictionary with some styles and converters I like to use all over:

![image](https://user-images.githubusercontent.com/2738836/69596726-d337ac00-0fc0-11ea-85f6-8748386d2d0c.png)

I use relative paths, because it seems simpler to me to do it this way rather than the rather complicated absolute uri path.

When I call SetColorTheme(), the application crashes when it's trying to enumerate the resource dictionaries.
`            ResourceLocator.SetColorScheme(Application.Current.Resources, Settings.DarkTheme ? ResourceLocator.DarkColorScheme : ResourceLocator.LightColorScheme);`

Looking at the exception and the code involved, it is because it does not check if it is an absolute or relative URI before it tries to resolve an absolute URI.

![image](https://user-images.githubusercontent.com/2738836/69596828-2dd10800-0fc1-11ea-854a-c2d67fa1fa49.png)

This PR adds a check for this to prevent an exception. My code no longer throws an exception and everything works as it should.