### PR TITLE
Add DarkEmber color scheme

### DIFF
--- a/AdonisUI.Demo/MainWindow.xaml.cs
+++ b/AdonisUI.Demo/MainWindow.xaml.cs
@@ -30,13 +30,44 @@ namespace AdonisUI.Demo
             InitializeComponent();
         }
 
-        private bool _isDark;
+        private enum Theme
+        {
+            Light,
+            Dark,
+            DarkEmber
+        }
+
+        private Theme _currentTheme;
+
+        private static Uri GetColorScheme(Theme theme)
+        {
+            switch (theme)
+            {
+                case Theme.Light: return ResourceLocator.LightColorScheme;
+                case Theme.Dark: return ResourceLocator.DarkColorScheme;
+                case Theme.DarkEmber: return ResourceLocator.DarkEmberColorScheme;
+                default: throw new NotSupportedException("This theme is not supported");
+            }
+        }
 
         private void ChangeTheme(object sender, RoutedEventArgs e)
         {
-            ResourceLocator.SetColorScheme(Application.Current.Resources, _isDark ? ResourceLocator.LightColorScheme : ResourceLocator.DarkColorScheme);
-
-            _isDark = !_isDark;
+            Theme newTheme;
+            switch (_currentTheme)
+            {
+                case Theme.Light:
+                    newTheme = Theme.Dark;
+                    break;
+                case Theme.Dark:
+                    newTheme = Theme.DarkEmber;
+                    break;
+                case Theme.DarkEmber:
+                    newTheme = Theme.Light;
+                    break;
+                default: throw new NotSupportedException("This theme is not supported");
+            }
+            ResourceLocator.SetColorScheme(Application.Current.Resources, GetColorScheme(newTheme), GetColorScheme(_currentTheme));
+            _currentTheme = newTheme;
         }
 
         private void OpenIssueDialog(object sender, RoutedEventArgs e)

--- a/AdonisUI/ColorSchemes/DarkEmber.xaml
+++ b/AdonisUI/ColorSchemes/DarkEmber.xaml
@@ -1,0 +1,139 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:adonisUi="clr-namespace:AdonisUI">
+
+    <!-- colors -->
+
+    <Color x:Key="{x:Static adonisUi:Colors.AccentColor}">#f98b21</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AccentHighlightColor}">#fa983a</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AccentIntenseHighlightColor}">#f8aa3b</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AccentIntenseHighlightBorderColor}">#f8aa3b</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AccentInteractionColor}">#f9a23b</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AccentInteractionBorderColor}">#f9a23b</Color>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.AccentInteractionForegroundColor}" ResourceKey="{x:Static adonisUi:Colors.AccentForegroundColor}"/>
+
+    <Color x:Key="{x:Static adonisUi:Colors.Layer0BackgroundColor}">#2A2B34</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer0BorderColor}">#2A2B34</Color>
+
+    <Color x:Key="{x:Static adonisUi:Colors.Layer1BackgroundColor}">#3D3D4C</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer1BorderColor}">#4A4A5E</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer1HighlightColor}">#4C4F62</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer1HighlightBorderColor}">#727290</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer1IntenseHighlightColor}">#5C5F74</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer1IntenseHighlightBorderColor}">#A9A9C0</Color>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer1InteractionColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer1InteractionBorderColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer1InteractionForegroundColor}" ResourceKey="{x:Static adonisUi:Colors.AccentForegroundColor}"/>
+
+    <Color x:Key="{x:Static adonisUi:Colors.Layer2BackgroundColor}">#32323F</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer2BorderColor}">#272730</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer2HighlightColor}">#3D3D4C</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer2HighlightBorderColor}">#585871</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer2IntenseHighlightColor}">#454555</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer2IntenseHighlightBorderColor}">#7B7B99</Color>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer2InteractionColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer2InteractionBorderColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer2InteractionForegroundColor}" ResourceKey="{x:Static adonisUi:Colors.AccentForegroundColor}"/>
+
+    <Color x:Key="{x:Static adonisUi:Colors.Layer3BackgroundColor}">#262630</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer3BorderColor}">#1F2029</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer3HighlightColor}">#3B3D4A</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer3HighlightBorderColor}">#484B60</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer3IntenseHighlightColor}">#464859</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer3IntenseHighlightBorderColor}">#717590</Color>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer3InteractionColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer3InteractionBorderColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer3InteractionForegroundColor}" ResourceKey="{x:Static adonisUi:Colors.AccentForegroundColor}"/>
+
+    <Color x:Key="{x:Static adonisUi:Colors.Layer4BackgroundColor}">#323341</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer4BorderColor}">#414255</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer4HighlightColor}">#38394A</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer4HighlightBorderColor}">#51516B</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer4IntenseHighlightColor}">#48495C</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.Layer4IntenseHighlightBorderColor}">#7F7F90</Color>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer4InteractionColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer4InteractionBorderColor}" ResourceKey="{x:Static adonisUi:Colors.AccentColor}"/>
+    <DynamicResource x:Key="{x:Static adonisUi:Colors.Layer4InteractionForegroundColor}" ResourceKey="{x:Static adonisUi:Colors.AccentForegroundColor}"/>
+
+    <Color x:Key="{x:Static adonisUi:Colors.ForegroundColor}">#f0f0f0</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AccentForegroundColor}">#ffffff</Color>
+
+    <Color x:Key="{x:Static adonisUi:Colors.DisabledForegroundColor}">#8E8E8E</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.DisabledAccentForegroundColor}">#ACACAC</Color>
+
+    <Color x:Key="{x:Static adonisUi:Colors.SuccessColor}">#00b14a</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.ErrorColor}">#b00020</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.AlertColor}">#ffc107</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.HyperlinkColor}">#e58e26</Color>
+
+    <Color x:Key="{x:Static adonisUi:Colors.WindowButtonHighlightColor}">#3D3D4C</Color>
+    <Color x:Key="{x:Static adonisUi:Colors.WindowButtonInteractionColor}">#4C4F62</Color>
+
+    <!-- brushes -->
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentIntenseHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentIntenseHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentIntenseHighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentIntenseHighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentInteractionBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentInteractionColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentInteractionBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentInteractionBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentInteractionForegroundBrush}" Color="{StaticResource {x:Static adonisUi:Colors.AccentInteractionForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer0BackgroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer0BackgroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer0BorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer0BorderColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1BackgroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer1BackgroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1BorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer1BorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1HighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer1HighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1HighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer1HighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1IntenseHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer1IntenseHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1IntenseHighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer1IntenseHighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1InteractionBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer1InteractionColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1InteractionBorderBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer1InteractionBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer1InteractionForegroundBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer1InteractionForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2BackgroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer2BackgroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2BorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer2BorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2HighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer2HighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2HighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer2HighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2IntenseHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer2IntenseHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2IntenseHighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer2IntenseHighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2InteractionBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer2InteractionColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2InteractionBorderBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer2InteractionBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer2InteractionForegroundBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer2InteractionForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3BackgroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer3BackgroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3BorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer3BorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3HighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer3HighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3HighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer3HighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3IntenseHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer3IntenseHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3IntenseHighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer3IntenseHighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3InteractionBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer3InteractionColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3InteractionBorderBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer3InteractionBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer3InteractionForegroundBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer3InteractionForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4BackgroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer4BackgroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4BorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer4BorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4HighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer4HighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4HighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer4HighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4IntenseHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer4IntenseHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4IntenseHighlightBorderBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.Layer4IntenseHighlightBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4InteractionBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer4InteractionColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4InteractionBorderBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer4InteractionBorderColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.Layer4InteractionForegroundBrush}" Color="{StaticResource {x:Static adonisUi:Colors.Layer4InteractionForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.ForegroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.ForegroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AccentForegroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AccentForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.DisabledForegroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.DisabledForegroundColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.DisabledAccentForegroundBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.DisabledAccentForegroundColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.SuccessBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.SuccessColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.ErrorBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.ErrorColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.AlertBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.AlertColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.HyperlinkBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.HyperlinkColor}}"/>
+
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.WindowButtonHighlightBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.WindowButtonHighlightColor}}"/>
+    <SolidColorBrush x:Key="{x:Static adonisUi:Brushes.WindowButtonInteractionBrush}" Color="{DynamicResource {x:Static adonisUi:Colors.WindowButtonInteractionColor}}"/>
+
+</ResourceDictionary>

--- a/AdonisUI/ResourceLocator.cs
+++ b/AdonisUI/ResourceLocator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +16,8 @@ namespace AdonisUI
 
         public static Uri DarkColorScheme => new Uri("pack://application:,,,/AdonisUI;component/ColorSchemes/Dark.xaml", UriKind.Absolute);
 
+        public static Uri DarkEmberColorScheme => new Uri("pack://application:,,,/AdonisUI;component/ColorSchemes/DarkEmber.xaml", UriKind.Absolute);
+
         /// <summary>
         /// Adds a resource dictionary with the specified uri to the MergedDictionaries collection of the <see cref="rootResourceDictionary"/>.
         /// Additionally all child ResourceDictionaries are traversed recursively to find the current color scheme which is removed if found.
@@ -25,7 +27,7 @@ namespace AdonisUI
         /// <param name="currentColorSchemeResourceUri">Optional uri to an external color scheme that is not provided by AdonisUI.</param>
         public static void SetColorScheme(ResourceDictionary rootResourceDictionary, Uri colorSchemeResourceUri, Uri currentColorSchemeResourceUri = null)
         {
-            Uri[] knownColorSchemes = currentColorSchemeResourceUri != null ? new [] { currentColorSchemeResourceUri } : new [] { LightColorScheme, DarkColorScheme};
+            Uri[] knownColorSchemes = currentColorSchemeResourceUri != null ? new [] { currentColorSchemeResourceUri } : new [] { LightColorScheme, DarkColorScheme, DarkEmberColorScheme };
 
             ResourceDictionary currentTheme = FindColorSchemeInResources(rootResourceDictionary, knownColorSchemes);
 


### PR DESCRIPTION
## Summary
<!-- Summarize your changes briefly -->
This pull request adds a new color scheme to the existing ones. It uses the color palette from the Dark scheme, but changes the accent colors to variants of orange (from blue). 

**Please note**: This pull request does *not* include a change to the documentation. 

![Capture](https://user-images.githubusercontent.com/12814701/69730735-e5345e80-1128-11ea-8775-78c513f3b77d.PNG)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Especially orange fits pretty well for a dark theme and it increases the variety of available color options.

## Details
<!--- Describe your changes in detail -->
- Add DarkEmber.xaml
- Add DarkEmberColorScheme property to ResourceLocator
- Modify demo to loop over existing color schemes when clicking the 'Change theme' button (was toggling before)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.