### PR TITLE
Fix navigation does not match github pages' urls

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,7 @@ description: >- # this means to ignore newlines until next key
 github_username:  benruehl
 remote_theme: pmarsceill/just-the-docs
 theme: "just-the-docs"
+baseurl: /adonis-ui
 
 repository: benruehl/adonis-ui
 nuget_url: https://www.nuget.org/packages/AdonisUI.ClassicTheme/

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -5,7 +5,7 @@
         <li class="header-navigation-list-item">
             {%- assign page_url_segments = page.url | split: "/" -%}
             {%- assign node_url_segments = node.url | split: "/" -%}
-            <a class="{% if page_url_segments[1] == node_url_segments[1] %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
+            <a class="{% if page_url_segments[1] == node_url_segments[1] %} active{% endif %}" href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
         </li>
         {%- endfor -%}
     </ul>


### PR DESCRIPTION
The navigation does not respect the trailing `/adonis-ui` in `https://benruehl.github.io/adonis-ui/` which should get fixed here.