### PR TITLE
Fix ripple layer for MenuItem header style not respecting RecognizesAccessKey.

### DIFF
--- a/AdonisUI.ClassicTheme/DefaultStyles/MenuItem.xaml
+++ b/AdonisUI.ClassicTheme/DefaultStyles/MenuItem.xaml
@@ -86,7 +86,7 @@
                                                   Content="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static adonisConverters:IsImmutableFilterConverter.Instance}}"
                                                   ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                   TextElement.Foreground="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type adonisControls:RippleHost}}}"
-												  RecognizesAccessKey="True"
+                                                  RecognizesAccessKey="True"
                                                   VerticalAlignment="Center" 
                                                   HorizontalAlignment="Stretch" 
                                                   Margin="{Binding Margin, ElementName=ItemHeader}"/>

--- a/AdonisUI.ClassicTheme/DefaultStyles/MenuItem.xaml
+++ b/AdonisUI.ClassicTheme/DefaultStyles/MenuItem.xaml
@@ -86,6 +86,7 @@
                                                   Content="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static adonisConverters:IsImmutableFilterConverter.Instance}}"
                                                   ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                   TextElement.Foreground="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type adonisControls:RippleHost}}}"
+												  RecognizesAccessKey="True"
                                                   VerticalAlignment="Center" 
                                                   HorizontalAlignment="Stretch" 
                                                   Margin="{Binding Margin, ElementName=ItemHeader}"/>


### PR DESCRIPTION
The default style for `MenuItem` headers without the ripple layer correctly sets `RecognizeAccessKey` ([MenuItem.xaml#L140@5515312](https://github.com/benruehl/adonis-ui/blob/55153129215323c671c3563141befd3fdb8fa7c5/AdonisUI.ClassicTheme/DefaultStyles/MenuItem.xaml#L140)), however the ripple layer header template does not ([MenuItem.xaml#L88@5515312](https://github.com/benruehl/adonis-ui/55153129215323c671c3563141befd3fdb8fa7c5/master/AdonisUI.ClassicTheme/DefaultStyles/MenuItem.xaml#L88)), resulting in menu items with no children and a keyboard accelerator key displaying a literal underscore on mouse down.

![example](https://i.imgur.com/Lpj97Kn.png)