### PR TITLE
Fix uncaught exeption when app is started from different directory

### DIFF
--- a/AdonisUI/Controls/AdonisWindow.cs
+++ b/AdonisUI/Controls/AdonisWindow.cs
@@ -157,7 +157,7 @@ namespace AdonisUI.Controls
 
         private BitmapSource GetApplicationIcon()
         {
-            Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly()?.ManifestModule.Name);
+            Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly()?.ManifestModule.FullyQualifiedName);
 
             if (appIcon == null)
                 return null;


### PR DESCRIPTION
`Assembly.GetEntryAssembly()?.ManifestModule.Name` returns the executable's name only (e.g `AdonisUI.Demo.exe`) whereas `Assembly.GetEntryAssembly()?.ManifestModule.FullyQualifiedName` returns the full path (e.g `C:\AdonisUI.Demo.exe`).

This is important for cases where the application is started via CLI from a different directory. The full path is required here in order to resolve the assembly the icon is extracted from.

Fixes #63