### PR TITLE
Fix tree view item binding to attached property sometimes not working…

### DIFF
--- a/AdonisUI.ClassicTheme/DefaultStyles/TreeView.xaml
+++ b/AdonisUI.ClassicTheme/DefaultStyles/TreeView.xaml
@@ -157,7 +157,7 @@
 
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding (adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
+                    <Condition Binding="{Binding Path=(adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
                     <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
@@ -171,7 +171,7 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(adonisExtensions:LayerExtension.ComputedLayer), RelativeSource={RelativeSource Self}}" Value="2"/>
-                    <Condition Binding="{Binding (adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
+                    <Condition Binding="{Binding Path=(adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
                     <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
@@ -185,7 +185,7 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(adonisExtensions:LayerExtension.ComputedLayer), RelativeSource={RelativeSource Self}}" Value="3"/>
-                    <Condition Binding="{Binding (adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
+                    <Condition Binding="{Binding Path=(adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
                     <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
@@ -199,7 +199,7 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(adonisExtensions:LayerExtension.ComputedLayer), RelativeSource={RelativeSource Self}}" Value="4"/>
-                    <Condition Binding="{Binding (adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
+                    <Condition Binding="{Binding Path=(adonisExtensions:TreeViewItemMouseOverExtension.IsMouseDirectlyOverItem), RelativeSource={RelativeSource Self}}" Value="True" />
                     <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>


### PR DESCRIPTION
The static initializer of `TreeViewItemMouseOverExtension` did not get triggered in some demo application. No idea why, but explicitly adding `Path="..."` fixed the issue in the application.

Fixes #66 