### PR TITLE
Fix for ContentSite misaligning PART_EditableTextBox when editing (ComboBox)

### DIFF
--- a/AdonisUI.ClassicTheme/DefaultStyles/ComboBox.xaml
+++ b/AdonisUI.ClassicTheme/DefaultStyles/ComboBox.xaml
@@ -365,7 +365,7 @@
                         <Trigger Property="IsEditable" Value="True">
                             <Setter Property="KeyboardNavigation.IsTabStop" Value="False"/>
                             <Setter Property="UIElement.Visibility" TargetName="PART_EditableTextBox" Value="Visible"/>
-                            <Setter Property="UIElement.Visibility" TargetName="ContentSite" Value="Hidden"/>
+                            <Setter Property="UIElement.Visibility" TargetName="ContentSite" Value="Collapsed"/>
                             <Setter Property="HorizontalAlignment" TargetName="ToggleButton" Value="Right"/>
                             <Setter Property="HorizontalAlignment" TargetName="ToggleButton" Value="Right"/>
                         </Trigger>


### PR DESCRIPTION
**Describe the bug**
When a ComboBox flips between IsEditable true/false, the editable textbox (PART_EditableTextBox) gets misaligned due to the width of the hidden ContentSite.

Collapsing ContentSite instead of hiding it fixes this issue.

**To Reproduce**
Steps to reproduce the behavior:

1. Initialize IsEditable to "False" on a ComboBox using the default AdonisUI style.
2. While the app is running, set IsEditable to true while the ComboBox has a valid item name.
3. The editable textbox is pushed to the right from the ContentSite's width.

**Expected behavior**
PART_EditableTextBox should be in the same spot that ContentSite is, so the text is aligned when switching between IsEditable  true/false.

**Screenshots**
Example when using Visibility.Hidden:

[![When using Hidden for Visibility](https://thumbs.gfycat.com/HoarseWeeItaliangreyhound-size_restricted.gif)](https://gfycat.com/HoarseWeeItaliangreyhound)

Example when using Visibility.Collapsed (expected/desired behavior):

[![When using Collapsed for Visibility](https://thumbs.gfycat.com/PopularAptLeech-size_restricted.gif)](https://gfycat.com/PopularAptLeech)