### PR TITLE
Fix for Net Core self contained WPF apps

### DIFF
--- a/AdonisUI/Controls/AdonisWindow.cs
+++ b/AdonisUI/Controls/AdonisWindow.cs
@@ -157,7 +157,7 @@ namespace AdonisUI.Controls
 
         private BitmapSource GetApplicationIcon()
         {
-            Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly()?.ManifestModule.FullyQualifiedName);
+            Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetExecutingAssembly()?.ManifestModule.FullyQualifiedName);
 
             if (appIcon == null)
                 return null;


### PR DESCRIPTION
This is fix for self-contained apps using **SelfContained** property or packed by Warp https://github.com/dgiagio/warp

Normally ExtractAssociatedIcon method will fail and app wont run, because GetEntryAssembly will return assembly of Warp Runner. 