### PR TITLE
Add option to disable title bar shrinking when maximized

### DIFF
--- a/docs/docs/guides/window.md
+++ b/docs/docs/guides/window.md
@@ -23,7 +23,7 @@ To set the colors of the window's title bar the following properties can be used
 - `TitleBarBackground` - Sets the background brush of the window's title bar
 - `WindowButtonHighlightBrush` - Sets the background brush for the window buttons on hovering
 
-## Content
+## Title bar content
 
 By default, the title bar consists of the *application icon* on the left, the *window title* next to it and the *window buttons* on the right. The `AdonisWindow` class offers the following properties to modify this setup:
 
@@ -49,4 +49,14 @@ When adding buttons to the title bar, the `WindowButton` style can be used to ma
     </adonisControls:AdonisWindow.TitleBarContent>
     
 </adonisControls:AdonisWindow>
+```
+
+## Title bar size
+
+The title bar aims at behaving exactly like the default native title bar. That's why it shrinks a little when the window is maximized.
+
+This can be disabled by setting `ShrinkTitleBarWhenMaximized` on `AdonisWindow` to `false`.
+
+```xml
+<adonisControls:AdonisWindow ShrinkTitleBarWhenMaximized="False"/>
 ```

--- a/src/AdonisUI.ClassicTheme/NamedStyles/WindowButton.xaml
+++ b/src/AdonisUI.ClassicTheme/NamedStyles/WindowButton.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:adonisUi="clr-namespace:AdonisUI;assembly=AdonisUI"
-                    xmlns:adonisExtensions="clr-namespace:AdonisUI.Extensions;assembly=AdonisUI">
+                    xmlns:adonisExtensions="clr-namespace:AdonisUI.Extensions;assembly=AdonisUI"
+                    xmlns:controls="clr-namespace:AdonisUI.Controls;assembly=AdonisUI">
 
     <Style x:Key="{x:Static adonisUi:Styles.WindowButton}"
            TargetType="Button">
@@ -79,9 +80,13 @@
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static adonisUi:Brushes.DisabledForegroundBrush}}"/>
             </DataTrigger>
 
-            <DataTrigger Binding="{Binding WindowState, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" Value="Maximized">
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding WindowState, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" Value="Maximized"/>
+                    <Condition Binding="{Binding ShrinkTitleBarWhenMaximized, RelativeSource={RelativeSource FindAncestor, AncestorType=controls:AdonisWindow}}" Value="True"/>
+                </MultiDataTrigger.Conditions>
                 <Setter Property="Height" Value="22"/>
-            </DataTrigger>
+            </MultiDataTrigger>
 
         </Style.Triggers>
     </Style>

--- a/src/AdonisUI/Controls/AdonisWindow.cs
+++ b/src/AdonisUI/Controls/AdonisWindow.cs
@@ -116,6 +116,16 @@ namespace AdonisUI.Controls
             private set => SetValue(MaximizeBorderThicknessPropertyKey, value);
         }
 
+        /// <summary>
+        /// Controls whether to shrink the title bar height a little when the window is maximized.
+        /// The default is <see langword="true"/> as this is how native windows behave.
+        /// </summary>
+        public bool ShrinkTitleBarWhenMaximized
+        {
+            get => (bool)GetValue(ShrinkTitleBarWhenMaximizedProperty);
+            set => SetValue(ShrinkTitleBarWhenMaximizedProperty, value);
+        }
+
         public static readonly DependencyProperty IconVisibilityProperty = DependencyProperty.Register("IconVisibility", typeof(Visibility), typeof(AdonisWindow), new PropertyMetadata(Visibility.Visible));
 
         protected internal static readonly DependencyProperty IconSourceProperty = DependencyProperty.Register("IconSource", typeof(ImageSource), typeof(AdonisWindow), new PropertyMetadata(null));
@@ -131,6 +141,8 @@ namespace AdonisUI.Controls
         protected internal static readonly DependencyPropertyKey MaximizeBorderThicknessPropertyKey = DependencyProperty.RegisterReadOnly("MaximizeBorderThickness", typeof(Thickness), typeof(AdonisWindow), new PropertyMetadata(new Thickness()));
 
         protected internal static readonly DependencyProperty MaximizeBorderThicknessProperty = MaximizeBorderThicknessPropertyKey.DependencyProperty;
+
+        public static readonly DependencyProperty ShrinkTitleBarWhenMaximizedProperty = DependencyProperty.Register("ShrinkTitleBarWhenMaximized", typeof(bool), typeof(AdonisWindow), new PropertyMetadata(true));
 
         static AdonisWindow()
         {

--- a/src/AdonisUI/Controls/AdonisWindow.cs
+++ b/src/AdonisUI/Controls/AdonisWindow.cs
@@ -75,7 +75,7 @@ namespace AdonisUI.Controls
         /// </summary>
         public object TitleBarContent
         {
-            get => (object)GetValue(TitleBarContentProperty);
+            get => GetValue(TitleBarContentProperty);
             set => SetValue(TitleBarContentProperty, value);
         }
 
@@ -84,8 +84,8 @@ namespace AdonisUI.Controls
         /// </summary>
         public Brush TitleBarForeground
         {
-            get { return (Brush)GetValue(TitleBarForegroundProperty); }
-            set { SetValue(TitleBarForegroundProperty, value); }
+            get => (Brush)GetValue(TitleBarForegroundProperty);
+            set => SetValue(TitleBarForegroundProperty, value);
         }
 
         /// <summary>
@@ -93,8 +93,8 @@ namespace AdonisUI.Controls
         /// </summary>
         public Brush TitleBarBackground
         {
-            get { return (Brush)GetValue(TitleBarBackgroundProperty); }
-            set { SetValue(TitleBarBackgroundProperty, value); }
+            get => (Brush)GetValue(TitleBarBackgroundProperty);
+            set => SetValue(TitleBarBackgroundProperty, value);
         }
 
         /// <summary>
@@ -103,8 +103,8 @@ namespace AdonisUI.Controls
         /// </summary>
         public Brush WindowButtonHighlightBrush
         {
-            get { return (Brush)GetValue(WindowButtonHighlightBrushProperty); }
-            set { SetValue(WindowButtonHighlightBrushProperty, value); }
+            get => (Brush)GetValue(WindowButtonHighlightBrushProperty);
+            set => SetValue(WindowButtonHighlightBrushProperty, value);
         }
 
         /// <summary>


### PR DESCRIPTION
This adds the property `ShrinkTitleBarWhenMaximized` to `AdonisWindow`. The default value is `true`. The property can be set to `false` to keep the original title bar size when the window is maximized.

Resolves #81