### PR TITLE
[BUGFIX] AdonisWindow not being able to handle setting the IconProperty manually

### DIFF
--- a/src/AdonisUI/Controls/AdonisWindow.cs
+++ b/src/AdonisUI/Controls/AdonisWindow.cs
@@ -155,6 +155,12 @@ namespace AdonisUI.Controls
             if (!(d is AdonisWindow sourceWindow))
                 return;
 
+            if (e.NewValue is ImageSource image)
+            {
+                sourceWindow.IconSource = image;
+                return;
+            }
+
             string newIcon = e.NewValue.ToString();
 
             sourceWindow.IconSource = String.IsNullOrEmpty(newIcon) ? null : new BitmapImage(new Uri(newIcon));


### PR DESCRIPTION
When setting the IconProperty of a (Adonis-)Window instance, a ``System.UriFormatException`` is being thrown from [this](https://github.com/benruehl/adonis-ui/blob/16ae410a4c4cd4e36a8d7e7b898676765e9ee52b/src/AdonisUI/Controls/AdonisWindow.cs#L158) line, when the ``ToString`` method of that object doesnt evaluate to a valid Uri.

Such is the case for objects that represent an actual image, such as any class that derives from ``ImageSource``.

This PR takes those cases into account and skips the fallback logic that tries turning them into valid URIs.