### PR TITLE
Fix error in xaml designer caused by space extension

### DIFF
--- a/src/AdonisUI.ClassicTheme/DefaultStyles/GroupBox.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/GroupBox.xaml
@@ -13,7 +13,7 @@
         <Setter Property="adonisExtensions:CornerRadiusExtension.CornerRadius" Value="{DynamicResource {x:Static adonisUi:Dimensions.CornerRadius}}"/>
         <Setter Property="adonisExtensions:LayerExtension.IncreaseLayer" Value="True"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="Padding" Value="{adonisUi:Space 1}"/>
+        <Setter Property="Padding" Value="{adonisUi:Space 1, 1}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Template">

--- a/src/AdonisUI.ClassicTheme/DefaultStyles/ScrollViewer.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/ScrollViewer.xaml
@@ -10,7 +10,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="Padding" Value="{adonisUi:Space 0.5}"/>
+        <Setter Property="Padding" Value="{adonisUi:Space 0.5, 0.5}"/>
         <Setter Property="adonisExtensions:CornerRadiusExtension.CornerRadius" Value="{DynamicResource {x:Static adonisUi:Dimensions.CornerRadius}}"/>
         <Setter Property="adonisExtensions:ScrollViewerExtension.VerticalScrollBarExpansionMode" Value="ExpandOnHover"/>
         <Setter Property="adonisExtensions:ScrollViewerExtension.HorizontalScrollBarExpansionMode" Value="ExpandOnHover"/>

--- a/src/AdonisUI/SpaceExtension.cs
+++ b/src/AdonisUI/SpaceExtension.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;
@@ -11,6 +11,12 @@ namespace AdonisUI
     public class SpaceExtension
         : MarkupExtension
     {
+        private const double DesignModeHorizontalSpace = 8;
+
+        private const double DesignModeVerticalSpace = 8;
+
+        private static readonly bool IsInDesignMode = DesignerProperties.GetIsInDesignMode(new DependencyObject());
+
         private static double? _cachedHorizontalSpace;
 
         private static double? _cachedVerticalSpace;
@@ -226,7 +232,17 @@ namespace AdonisUI
             if (_cachedHorizontalSpace.HasValue)
                 return _cachedHorizontalSpace.Value;
 
-            FindAndCacheSpaceResources(service);
+            try
+            {
+                FindAndCacheSpaceResources(service);
+            }
+            catch
+            {
+                if (IsInDesignMode)
+                    return DesignModeHorizontalSpace;
+
+                throw;
+            }
 
             if (!_cachedHorizontalSpace.HasValue)
                 throw new Exception("Dimensions.HorizontalSpace could not be retrieved.");
@@ -239,7 +255,17 @@ namespace AdonisUI
             if (_cachedVerticalSpace.HasValue)
                 return _cachedVerticalSpace.Value;
 
-            FindAndCacheSpaceResources(service);
+            try
+            {
+                FindAndCacheSpaceResources(service);
+            }
+            catch
+            {
+                if (IsInDesignMode)
+                    return DesignModeVerticalSpace;
+
+                throw;
+            }
 
             if (!_cachedVerticalSpace.HasValue)
                 throw new Exception("Dimensions.VerticalSpace could not be retrieved.");


### PR DESCRIPTION
This aims at solving design time errors caused by the `SpaceExtension`. It is not really proven that this actually helps because the errors appear and disappear kind of randomly. Both changes seem to affect the designer in some kind though. All errors appear only when the xaml designer is enabled.

- Add special treatment of the design mode to the space markup extension
- Specify multiple parameters for space extension usages in style setters

Fixes #89