### PR TITLE
Add support for `WindowStyle="None"` to AdonisWindow

### DIFF
--- a/src/AdonisUI/Controls/AdonisWindow.xaml
+++ b/src/AdonisUI/Controls/AdonisWindow.xaml
@@ -198,12 +198,17 @@
                             <Setter TargetName="PART_MaximizeRestoreButton" Property="IsEnabled" Value="False"/>
                         </Trigger>
 
+                        <Trigger Property="WindowStyle" Value="None">
+                            <Setter TargetName="TitleBar" Property="Visibility" Value="Collapsed"/>
+                        </Trigger>
+
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
 
         <Style.Triggers>
+
             <Trigger Property="WindowState" Value="Maximized">
                 <Setter Property="WindowChrome.WindowChrome">
                     <Setter.Value>
@@ -215,6 +220,16 @@
                     </Setter.Value>
                 </Setter>
             </Trigger>
+
+            <Trigger Property="WindowStyle" Value="None">
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="WindowChrome.WindowChrome">
+                    <Setter.Value>
+                        <WindowChrome CaptionHeight="0"/>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+
         </Style.Triggers>
     </Style>
 


### PR DESCRIPTION
Add support for `WindowStyle="None"` to AdonisWindow.

- The title bar will be collapsed
- The window is still resizable
- The window still has a drop shadow (use `AllowTransparency="True"` to disable it)

Resolves #99