### PR TITLE
Fix watermark alignment

### DIFF
--- a/src/AdonisUI.ClassicTheme/DefaultStyles/ComboBox.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/ComboBox.xaml
@@ -274,8 +274,8 @@
                                             <Grid>
                                                 <ContentPresenter x:Name="PlaceholderHost"
                                                                   Content="{Binding Path=(adonisExtensions:WatermarkExtension.Watermark), RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}}"
-                                                                  HorizontalAlignment="Stretch"
-                                                                  VerticalAlignment="Stretch"
+                                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                                   Opacity="0.5"
                                                                   IsHitTestVisible="False"
                                                                   Visibility="Collapsed"/>

--- a/src/AdonisUI.ClassicTheme/DefaultStyles/DatePicker.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/DatePicker.xaml
@@ -22,8 +22,8 @@
                         <ContentPresenter x:Name="PlaceholderHost"
                                           Content="{Binding Path=(adonisExtensions:WatermarkExtension.Watermark), RelativeSource={RelativeSource FindAncestor, AncestorType=DatePicker}}"
                                           Margin="{TemplateBinding Padding}"
-                                          HorizontalAlignment="Stretch"
-                                          VerticalAlignment="Stretch"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           Opacity="0.5"
                                           IsHitTestVisible="False"
                                           Visibility="Collapsed"/>

--- a/src/AdonisUI.ClassicTheme/DefaultStyles/TextBox.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/TextBox.xaml
@@ -129,8 +129,8 @@
                             <Grid>
                                 <ContentPresenter x:Name="PlaceholderHost"
                                                   Content="{TemplateBinding adonisExtensions:WatermarkExtension.Watermark}"
-                                                  HorizontalAlignment="Stretch"
-                                                  VerticalAlignment="Stretch"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   Opacity="0.5"
                                                   IsHitTestVisible="False"
                                                   Visibility="Collapsed"/>


### PR DESCRIPTION
Fix alignment of watermark hosts in text boxes, combo boxes and date pickers. Watermarks did not respect content alignment properties resulting in misplaced watermarks when the controls' heights were specified explicitly.