### PR TITLE
Fix content alignment for bullet decorators

### DIFF
--- a/src/AdonisUI.ClassicTheme/DefaultStyles/CheckBox.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/CheckBox.xaml
@@ -12,6 +12,8 @@
         <Setter Property="BorderThickness" Value="{DynamicResource {x:Static adonisUi:Dimensions.BorderThickness}}"/>
         <Setter Property="adonisExtensions:CornerRadiusExtension.CornerRadius" Value="{DynamicResource {x:Static adonisUi:Dimensions.CornerRadius}}"/>
         <Setter Property="Padding" Value="{adonisUi:Space 0.5, 0, 0, 0}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="False"/>
         <Setter Property="Validation.ErrorTemplate" Value="{x:Null}"/>
@@ -21,6 +23,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="CheckBox">
                     <BulletDecorator Background="Transparent"
+                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                      SnapsToDevicePixels="False">
                         <BulletDecorator.Bullet>
                             <Border x:Name="Border"
@@ -87,8 +90,8 @@
                                                                      Margin="4, 0, 0, 0"/>
 
                             <ContentPresenter Margin="{TemplateBinding Padding}"
-                                              VerticalAlignment="Center"
-                                              HorizontalAlignment="Left"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               RecognizesAccessKey="True"/>
 
                         </DockPanel>

--- a/src/AdonisUI.ClassicTheme/DefaultStyles/RadioButton.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/RadioButton.xaml
@@ -9,17 +9,20 @@
         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static adonisUi:Brushes.Layer1BorderBrush}}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource {x:Static adonisUi:Dimensions.BorderThickness}}"/>
         <Setter Property="Padding" Value="{adonisUi:Space 0.5, 0, 0, 0}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="RadioButton">
-                    <BulletDecorator Background="Transparent">
+                    <BulletDecorator Background="Transparent"
+                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                         <BulletDecorator.Bullet>
-                            <Grid Width="14" 
-                                  Height="14" >
-                        
-                                <Ellipse x:Name="Border"  
+                            <Grid Width="14"
+                                  Height="14">
+
+                                <Ellipse x:Name="Border"
                                          Fill="{TemplateBinding Background}"
                                          StrokeThickness="{TemplateBinding BorderThickness}"
                                          Stroke="{TemplateBinding BorderBrush}" />
@@ -32,8 +35,8 @@
                         </BulletDecorator.Bullet>
 
                         <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="Center"
-                                          HorizontalAlignment="Left"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           RecognizesAccessKey="True"/>
                     </BulletDecorator>
 


### PR DESCRIPTION
Fix content alignment not being respected by bullet decorators in check boxes and radio buttons.