### PR TITLE
Address `Allow hiding of the window title in the title bar #127`

### DIFF
--- a/docs/docs/guides/window.md
+++ b/docs/docs/guides/window.md
@@ -28,6 +28,7 @@ To set the colors of the window's title bar the following properties can be used
 By default, the title bar consists of the *application icon* on the left, the *window title* next to it and the *window buttons* on the right. The `AdonisWindow` class offers the following properties to modify this setup:
 
 - `IconVisibility` - Sets the visibility of the application icon
+- `TitleVisibility` - Sets the visibility of the window title
 - `TitleBarContent` - Sets content into the area between the title and the window buttons
 
 When adding buttons to the title bar, the `WindowButton` style can be used to make them appear equal to the default window buttons.

--- a/src/AdonisUI/Controls/AdonisWindow.cs
+++ b/src/AdonisUI/Controls/AdonisWindow.cs
@@ -98,6 +98,15 @@ namespace AdonisUI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the visibility of the title component of the window.
+        /// </summary>
+        public Visibility TitleVisibility
+        {
+            get => (Visibility)GetValue(TitleVisibilityProperty);
+            set => SetValue(TitleVisibilityProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets the background brush of the minimize, maximize and restore
         /// buttons when they are hovered.
         /// </summary>
@@ -135,6 +144,8 @@ namespace AdonisUI.Controls
         public static readonly DependencyProperty TitleBarForegroundProperty = DependencyProperty.Register("TitleBarForeground", typeof(Brush), typeof(AdonisWindow), new PropertyMetadata(null));
 
         public static readonly DependencyProperty TitleBarBackgroundProperty = DependencyProperty.Register("TitleBarBackground", typeof(Brush), typeof(AdonisWindow), new PropertyMetadata(null));
+
+        public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register("TitleVisibility", typeof(Visibility), typeof(AdonisWindow), new PropertyMetadata(Visibility.Visible));
 
         public static readonly DependencyProperty WindowButtonHighlightBrushProperty = DependencyProperty.Register("WindowButtonHighlightBrush", typeof(Brush), typeof(AdonisWindow), new PropertyMetadata(null));
 

--- a/src/AdonisUI/Controls/AdonisWindow.xaml
+++ b/src/AdonisUI/Controls/AdonisWindow.xaml
@@ -57,18 +57,25 @@
                                             </Grid.ColumnDefinitions>
 
                                             <Grid VerticalAlignment="Center"
-                                                  Margin="8, 0, 0, 0">
+                                                  Margin="3, 0, 0, 0">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
+
+                                                <Grid.Visibility>
+                                                    <MultiBinding Converter="{x:Static adonisConverters:AllVisibilitiesToVisibilityConverter.Instance}">
+                                                        <Binding Path="IconVisibility" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
+                                                        <Binding Path="TitleVisibility" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
+                                                    </MultiBinding>
+                                                </Grid.Visibility>
 
                                                 <Image x:Name="PART_IconPresenter"
                                                        Source="{Binding IconSource, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                                                        Visibility="{Binding IconVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                                                        Width="16"
                                                        Height="16"
-                                                       Margin="0, 0, 5, 0"/>
+                                                       Margin="5, 0, 0, 0"/>
 
                                                 <TextBlock Grid.Column="1"
                                                            Text="{Binding Title, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
@@ -77,7 +84,8 @@
                                                            FontSize="11.5"
                                                            RenderOptions.ClearTypeHint="Auto"
                                                            TextOptions.TextRenderingMode="Auto"
-                                                           TextOptions.TextFormattingMode="Display"/>
+                                                           TextOptions.TextFormattingMode="Display"
+                                                           Margin="5, 0, 0, 0"/>
                                             </Grid>
 
                                             <ContentPresenter Grid.Column="1"

--- a/src/AdonisUI/Controls/AdonisWindow.xaml
+++ b/src/AdonisUI/Controls/AdonisWindow.xaml
@@ -72,6 +72,7 @@
 
                                                 <TextBlock Grid.Column="1"
                                                            Text="{Binding Title, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
+                                                           Visibility="{Binding TitleVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                                                            VerticalAlignment="Center"
                                                            FontSize="11.5"
                                                            RenderOptions.ClearTypeHint="Auto"

--- a/src/AdonisUI/Converters/AllVisibilitiesToVisibilityConverter.cs
+++ b/src/AdonisUI/Converters/AllVisibilitiesToVisibilityConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+
+namespace AdonisUI.Converters
+{
+    /// <summary>
+    /// Takes multiple Visibilities as input and returns a single Visibility of the same value if they are all equal
+    /// or returns Visibility.Visible.
+    /// </summary>
+    class AllVisibilitiesToVisibilityConverter
+        : IMultiValueConverter
+    {
+        public static AllVisibilitiesToVisibilityConverter Instance = new AllVisibilitiesToVisibilityConverter();
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.OfType<Visibility>().All(x => x == Visibility.Collapsed))
+            {
+                return Visibility.Collapsed;
+            }
+
+            if (values.OfType<Visibility>().All(x => x == Visibility.Hidden))
+            {
+                return Visibility.Hidden;
+            }
+
+            return Visibility.Visible;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `TitleVisibility` property to `AdonisWindow` and maximizes the usable area for `TitleBarContent`:

![both](https://user-images.githubusercontent.com/3824342/96199216-4e96a900-0f57-11eb-971d-0c01481e4fd6.png)

![icon](https://user-images.githubusercontent.com/3824342/96199220-4f2f3f80-0f57-11eb-9b0b-d2fdcbea507f.png)

![title](https://user-images.githubusercontent.com/3824342/96199223-4fc7d600-0f57-11eb-8a1b-7c9e78ab3f2b.png)

![none](https://user-images.githubusercontent.com/3824342/96199222-4f2f3f80-0f57-11eb-9b3a-577b323d8b4f.png)