### PR TITLE
.NET 5 fix singlefile apps crashing on fetching app icon

### DIFF
--- a/src/AdonisUI/Controls/AdonisWindow.cs
+++ b/src/AdonisUI/Controls/AdonisWindow.cs
@@ -209,7 +209,7 @@ namespace AdonisUI.Controls
         private BitmapSource GetApplicationIcon()
         {
             string appFilePath = Process.GetCurrentProcess().MainModule.FileName;
-            if (File.Exists(appFilePath))
+            if (!File.Exists(appFilePath))
                 return null;
 
             Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(appFilePath);

--- a/src/AdonisUI/Controls/AdonisWindow.cs
+++ b/src/AdonisUI/Controls/AdonisWindow.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
@@ -206,7 +208,11 @@ namespace AdonisUI.Controls
 
         private BitmapSource GetApplicationIcon()
         {
-            Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly()?.ManifestModule.FullyQualifiedName);
+            string appFilePath = Process.GetCurrentProcess().MainModule.FileName;
+            if (File.Exists(appFilePath))
+                return null;
+
+            Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(appFilePath);
 
             if (appIcon == null)
                 return null;


### PR DESCRIPTION
Fixes #159 

When a application using AdonisUI uses .net5 was compiled as 

``<SelfContained>true</SelfContained>`` and 
``<PublishSingleFile>true</PublishSingleFile>`` 

then ``Assembly.GetEntryAssembly()?.ManifestModule.FullyQualifiedName`` won't return a valid filename.

I replaced that call with 
```cs
Process.GetCurrentProcess().MainModule.FileName
``` 
and also added a check for the returned path actually pointing to a valid file, just in case things change again in the future.