### PR TITLE
Update pipeline to create NuGet packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,3 @@ steps:
     solution: '$(solution)'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
-
-- task: VSTest@2
-  inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,3 +29,10 @@ steps:
     solution: '$(solution)'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- task: NuGetCommand@2
+  displayName: 'Pack NuGet packages'
+  inputs:
+    command: 'pack'
+    packagesToPack: '**/AdonisUI.csproj;**/AdonisUI.ClassicTheme.csproj'
+    versioningScheme: 'off'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,15 @@ steps:
     useGlobalJson: true
 
 - task: NuGetToolInstaller@1
+  displayName: 'Install NuGet'
 
 - task: NuGetCommand@2
+  displayName: 'Restore packages'
   inputs:
     restoreSolution: '$(solution)'
 
 - task: VSBuild@1
+  displayName: 'Build solution'
   inputs:
     solution: '$(solution)'
     platform: '$(buildPlatform)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-- task: NuGetCommand@2
+- task: DotNetCoreCLI@2
   displayName: 'Pack NuGet packages'
   inputs:
     command: 'pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,3 +39,11 @@ steps:
     command: 'pack'
     packagesToPack: '**/AdonisUI.csproj;**/AdonisUI.ClassicTheme.csproj'
     versioningScheme: 'off'
+    configuration: '$(buildConfiguration)'
+    packDestination: '$(Build.ArtifactStagingDirectory)'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish build artifacts'
+  inputs:
+    pathToPublish: '$(Build.ArtifactStagingDirectory)'
+    artifactName: drop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
-  buildConfiguration: 'Debug'
+  buildConfiguration: 'Release'
 
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
Add a `dotnet pack` step to the build pipeline so that a release pipeline can pick up the NuGet packages and deploy them to NuGet.