### PR TITLE
Fix for Issue #161

### DIFF
--- a/src/AdonisUI.ClassicTheme/DefaultStyles/TreeView.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/TreeView.xaml
@@ -147,6 +147,7 @@
 
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsLoaded, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
                     <Condition Binding="{Binding IsExpanded, RelativeSource={RelativeSource FindAncestor, AncestorType=TreeViewItem}}" Value="True" />
                     <Condition Binding="{Binding Items.Count, RelativeSource={RelativeSource FindAncestor, AncestorType=TreeViewItem}}" Value="1" />
                 </MultiDataTrigger.Conditions>


### PR DESCRIPTION
This is a fix for [Issue #161](https://github.com/benruehl/adonis-ui/issues/161).
The binding failure occurs when you dynamically populate the tree view at run time.