### PR TITLE
Size, Margin of TextBox inside editable ComboBox are fixed

### DIFF
--- a/src/AdonisUI.ClassicTheme/DefaultStyles/ComboBox.xaml
+++ b/src/AdonisUI.ClassicTheme/DefaultStyles/ComboBox.xaml
@@ -238,7 +238,8 @@
 
                         <Border Margin="0, 0, 11, 0">
 
-                            <DockPanel Margin="{TemplateBinding Padding}">
+                            <DockPanel x:Name="DockPanel0" 
+                                       Margin="{TemplateBinding Padding}">
 
                                 <adonisControls:ValidationErrorIndicator x:Name="ErrorAlertHost"
                                                                          ValidatedElement="{Binding ., RelativeSource={RelativeSource TemplatedParent}}"
@@ -263,6 +264,9 @@
                                          IsReadOnly="{TemplateBinding IsReadOnly}"
                                          Background="{TemplateBinding Background}"
                                          Foreground="{TemplateBinding Foreground}"
+                                         Height="{Binding ActualHeight, ElementName=DockPanel0}"
+                                         Width="{Binding ActualWidth, ElementName=DockPanel0}"
+                                         Margin="0"
                                          Visibility="Hidden" 
                                          HorizontalAlignment="Stretch"
                                          VerticalAlignment="Stretch"


### PR DESCRIPTION
Size and Margin of TextBox inside editable ComboBox are fixed to the ComboBox itself.

If the user would define a custom style and set the height, width and margin property, then these values would also be applied to the TextBox inside an editable ComboBox, which would misalign it. This issue has been fixed. As of now other style settings would still apply.