### PR TITLE
Update supported .NET versions (Housekeeping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 [![Build Status](https://dev.azure.com/devruehl/AdonisUI/_apis/build/status/benruehl.adonis-ui?branchName=master)](https://dev.azure.com/devruehl/AdonisUI/_build/latest?definitionId=1&branchName=master)
 [![NuGet version](https://img.shields.io/nuget/v/AdonisUi.ClassicTheme.svg)](https://www.nuget.org/packages/AdonisUI.ClassicTheme/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/AdonisUi.ClassicTheme.svg)](https://www.nuget.org/packages/AdonisUI.ClassicTheme/)
-![.NET Version: >= 5.0](https://img.shields.io/badge/.NET-%3E%3D%205.0-green.svg)
-![.NET Core Version: >= 3.1](https://img.shields.io/badge/.NET%20Core-%3E%3D%203.1-green.svg)
-![.NET Framework version: >= 4.5](https://img.shields.io/badge/.NET%20Framework-%3E%3D%204.5-green.svg)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)	
+![.NET Version: >= 8.0](https://img.shields.io/badge/.NET-%3E%3D%205.0-green.svg)
+![.NET Framework version: >= 4.6.2](https://img.shields.io/badge/.NET%20Framework-%3E%3D%204.5-green.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 Lightweight UI toolkit for WPF applications offering classic but enhanced windows visuals
 
@@ -34,7 +33,7 @@ Lightweight UI toolkit for WPF applications offering classic but enhanced window
 
 ## Getting started
 
-1. Reference `AdonisUI` and `AdonisUI.ClassicTheme` in your WPF project. It is available via [NuGet](https://www.nuget.org/packages/AdonisUI.ClassicTheme/) or [manual download](https://github.com/benruehl/adonis-ui/releases). Currently it requires at least .NET Framework 4.5 or .NET Core 3.0.
+1. Reference `AdonisUI` and `AdonisUI.ClassicTheme` in your WPF project. It is available via [NuGet](https://www.nuget.org/packages/AdonisUI.ClassicTheme/) or [manual download](https://github.com/benruehl/adonis-ui/releases). Currently it requires at least .NET Framework 4.6.2 or .NET 8.0.
 2. Add resources to your application in your `App.xaml` like so:
 
 ```xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 variables:
   solution: '**/*.sln'

--- a/docs/docs/getting-started/introduction.md
+++ b/docs/docs/getting-started/introduction.md
@@ -12,7 +12,7 @@ Get started with Adonis UI, a lightweight UI toolkit for WPF applications. Inclu
 
 ## Quick start
 
-1. Reference `AdonisUI` and `AdonisUI.ClassicTheme` in your WPF project. It is available via [NuGet](https://www.nuget.org/packages/AdonisUI.ClassicTheme/) or [manual download](https://github.com/benruehl/adonis-ui/releases). Currently it requires at least .NET 4.5 or .NET Core 3.0.
+1. Reference `AdonisUI` and `AdonisUI.ClassicTheme` in your WPF project. It is available via [NuGet](https://www.nuget.org/packages/AdonisUI.ClassicTheme/) or [manual download](https://github.com/benruehl/adonis-ui/releases). Currently it requires at least .NET 4.6.2 or .NET 8.0.
 2. Add resources to your application in your `App.xaml`:
 
     ```xml

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.400",
+        "version": "9.0.101",
         "rollForward": "latestMajor"
     }
 }

--- a/src/AdonisUI.ClassicTheme/AdonisUI.ClassicTheme.csproj
+++ b/src/AdonisUI.ClassicTheme/AdonisUI.ClassicTheme.csproj
@@ -1,11 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <!-- Build Settings -->
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows;net9.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <UseWpf>true</UseWpf>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <!-- Package metadata -->
@@ -34,12 +35,7 @@
   </PropertyGroup>
 
   <!-- Project References -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AdonisUI\AdonisUI.csproj" />
   </ItemGroup>

--- a/src/AdonisUI.Demo/AdonisUI.Demo.csproj
+++ b/src/AdonisUI.Demo/AdonisUI.Demo.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>AdonisUI.Demo</RootNamespace>
     <StartupObject>AdonisUI.Demo.App</StartupObject>
@@ -26,17 +26,11 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <ApplicationIcon>App.ico</ApplicationIcon>
     <Platforms>AnyCPU;x64;x86</Platforms>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed>false</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>false</PublishSingleFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AdonisUI\AdonisUI.csproj" />

--- a/src/AdonisUI/AdonisUI.csproj
+++ b/src/AdonisUI/AdonisUI.csproj
@@ -1,11 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <!-- Build Settings -->
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows;net9.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <UseWpf>true</UseWpf>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <!-- Package metadata -->
@@ -34,13 +35,7 @@
   </PropertyGroup>
 
   <!-- Project References -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
-    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Changes
- added .NET Framework 4.6.2 as replacement for  .NET Framework 4.5
- added .NET 8 and 9 as replacement for netcoreapp3.1
- updated System.Drawing.Common to latest version, to fix a CVE

# misc
- disabled warnings about missing xml headers (CS1591)
- disabled trimming for demo app since WPF never supported trimming